### PR TITLE
Make `abc.User` and `abc.PrivateChannel` support snowflakes

### DIFF
--- a/discord-stubs/abc.pyi
+++ b/discord-stubs/abc.pyi
@@ -27,7 +27,7 @@ class Snowflake(Protocol):
     def created_at(self) -> datetime.datetime: ...
 
 @runtime_checkable
-class User(Snowflake):
+class User(Snowflake, Protocol):
     name: str
     discriminator: str
     avatar: Optional[str]
@@ -40,7 +40,7 @@ class User(Snowflake):
     def mention(self) -> str: ...
 
 @runtime_checkable
-class PrivateChannel(Snowflake):
+class PrivateChannel(Snowflake, Protocol):
     me: ClientUser
 
 class GuildChannel:

--- a/discord-stubs/abc.pyi
+++ b/discord-stubs/abc.pyi
@@ -27,7 +27,7 @@ class Snowflake(Protocol):
     def created_at(self) -> datetime.datetime: ...
 
 @runtime_checkable
-class User(Protocol):
+class User(Snowflake):
     name: str
     discriminator: str
     avatar: Optional[str]
@@ -40,7 +40,7 @@ class User(Protocol):
     def mention(self) -> str: ...
 
 @runtime_checkable
-class PrivateChannel(Protocol):
+class PrivateChannel(Snowflake):
     me: ClientUser
 
 class GuildChannel:


### PR DESCRIPTION
Per discord.py's docs, these must also implement Snowflake (which is ensured by subclass hook), so these protocols should include the Snowflake protocol.