### PR TITLE
Use __init__ instead of __new__ for Bot constructors

### DIFF
--- a/discord-stubs/ext/commands/bot.pyi
+++ b/discord-stubs/ext/commands/bot.pyi
@@ -92,7 +92,7 @@ class BotBase(GroupMixin[_CT]):
 
 class Bot(BotBase[_CT], discord.Client):
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
@@ -120,9 +120,9 @@ class Bot(BotBase[_CT], discord.Client):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> Bot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
@@ -150,9 +150,9 @@ class Bot(BotBase[_CT], discord.Client):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> Bot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
@@ -179,11 +179,11 @@ class Bot(BotBase[_CT], discord.Client):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> Bot[Context]: ...
+    ) -> None: ...
 
 class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -211,9 +211,9 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -241,9 +241,9 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -270,9 +270,9 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -300,9 +300,9 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -330,9 +330,9 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...
     @overload
-    def __new__(
+    def __init__(
         self,
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
@@ -359,4 +359,4 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
         guild_ready_timeout: float = ...,
         guild_subscriptions: bool = ...,
         assume_unsync_clock: bool = ...,
-    ) -> AutoShardedBot[Context]: ...
+    ) -> None: ...

--- a/discord-stubs/ext/commands/bot.pyi
+++ b/discord-stubs/ext/commands/bot.pyi
@@ -93,7 +93,7 @@ class BotBase(GroupMixin[_CT]):
 class Bot(BotBase[_CT], discord.Client):
     @overload
     def __init__(
-        self,
+        self: Bot[Context],
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
         description: Optional[str] = ...,
@@ -123,7 +123,7 @@ class Bot(BotBase[_CT], discord.Client):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: Bot[Context],
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
         description: Optional[str] = ...,
@@ -153,7 +153,7 @@ class Bot(BotBase[_CT], discord.Client):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: Bot[Context],
         command_prefix: _CommandPrefix,
         help_command: Optional[HelpCommand[Context]] = ...,
         description: Optional[str] = ...,
@@ -184,7 +184,7 @@ class Bot(BotBase[_CT], discord.Client):
 class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,
@@ -214,7 +214,7 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,
@@ -244,7 +244,7 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,
@@ -273,7 +273,7 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,
@@ -303,7 +303,7 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,
@@ -333,7 +333,7 @@ class AutoShardedBot(BotBase[_CT], discord.AutoShardedClient):
     ) -> None: ...
     @overload
     def __init__(
-        self,
+        self: AutoShardedBot[Context],
         command_prefix: _CommandPrefix,
         help_command: HelpCommand[Context] = ...,
         description: Optional[str] = ...,


### PR DESCRIPTION
Pylance was complaining about no overload found whenever the Bot
class would be inherited and provided their own constructor.

I noticed the stubs used `__new__` instead of `__init__` so I
changed it to reflect the actual code in discord.py (which does not
use `__new__`). I tested this in both Pylance and Mypy and it seems
to work without issues.

I wasn't overly sure why `__new__` was chosen instead of `__init__` here though.

The issue this fixed can be summarised with the following image:

![image of broken behaviour](https://cdn.discordapp.com/attachments/336642776609456130/816153405407625216/unknown.png)

