### PR TITLE
Add BytesIO and StringIO typehints to File class

### DIFF
--- a/discord-stubs/file.pyi
+++ b/discord-stubs/file.pyi
@@ -1,12 +1,13 @@
 from typing import BinaryIO, Optional, Union
+from io import BytesIO, StringIO
 
 class File:
-    fp: Union[str, BinaryIO]
+    fp: Union[str, BinaryIO, BytesIO, StringIO]
     filename: Optional[str]
     spoiler: bool
     def __init__(
         self,
-        fp: Union[str, BinaryIO],
+        fp: Union[str, BinaryIO, BytesIO, StringIO],
         filename: Optional[str] = ...,
         *,
         spoiler: bool = ...,


### PR DESCRIPTION
Using a BytesIO or StringIO instance as a buffer to pass to a discord File is useful and perfectly correct.

I thus think that it would be fine to add it as a typehint.

However, I did not found a generic typehint for those two, if one exists it will of course be much better to add that one.