### PR TITLE
Change type of bot.commands to be a Set

### DIFF
--- a/discord-stubs/ext/commands/core.pyi
+++ b/discord-stubs/ext/commands/core.pyi
@@ -9,6 +9,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -143,7 +144,7 @@ class GroupMixin(Generic[_CT]):
     all_commands: Dict[str, Command[_CT]]
     case_insensitive: bool
     @property
-    def commands(self) -> ValuesView[Command[_CT]]: ...
+    def commands(self) -> Set[Command[_CT]]: ...
     def recursively_remove_all_commands(self) -> None: ...
     def add_command(self, command: Command[_CT]) -> None: ...
     def remove_command(self, name: str) -> Optional[Command[_CT]]: ...

--- a/discord-stubs/ext/commands/core.pyi
+++ b/discord-stubs/ext/commands/core.pyi
@@ -14,7 +14,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    ValuesView,
     overload,
     type_check_only,
 )


### PR DESCRIPTION
According to https://github.com/Rapptz/discord.py/blob/6f3b8072d6d069e5df04af62e93f673b576ab4c0/discord/ext/commands/core.py#L1077-L1080, the values are converted to a Set.