### PR TITLE
Add missing `http` attribute to `client.pyi`

### DIFF
--- a/discord-stubs/client.pyi
+++ b/discord-stubs/client.pyi
@@ -32,6 +32,7 @@ from .enums import Status, VoiceRegion
 from .flags import Intents, MemberCacheFlags
 from .gateway import DiscordWebSocket
 from .guild import Guild
+from .http import HTTPClient
 from .invite import Invite
 from .iterators import GuildIterator
 from .member import Member, VoiceState
@@ -66,6 +67,7 @@ class Client:
     loop: asyncio.AbstractEventLoop
     shard_id: Optional[int]
     shard_count: Optional[int]
+    http: HTTPClient
     activity: Optional[BaseActivity]
     allowed_mentions: Optional[AllowedMentions]
     def __init__(


### PR DESCRIPTION
As the title says.

Not sure if this was deliberately left out or just missed, but it meant I got a load of mypy errors in my bot.