### PR TITLE
Add types for Emoji constructor

### DIFF
--- a/discord-stubs/emoji.pyi
+++ b/discord-stubs/emoji.pyi
@@ -1,10 +1,11 @@
 import datetime
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from .asset import _VALID_ANIMATED_ICON_FORMATS, _VALID_STATIC_ICON_FORMATS, Asset
 from .guild import Guild
 from .partial_emoji import _EmojiTag
 from .role import Role
+from .state import ConnectionState
 from .user import User
 
 class Emoji(_EmojiTag):
@@ -16,6 +17,13 @@ class Emoji(_EmojiTag):
     guild_id: int
     available: bool
     user: Optional[User]
+    def __init__(
+        self,
+        *,
+        guild: Guild,
+        state: ConnectionState,
+        data: Dict[str, Any],
+    ) -> None: ...
     def __iter__(self) -> Iterator[Tuple[str, Any]]: ...
     def __eq__(self, other: Any) -> bool: ...
     def __ne__(self, other: Any) -> bool: ...

--- a/discord-stubs/partial_emoji.pyi
+++ b/discord-stubs/partial_emoji.pyi
@@ -3,6 +3,7 @@ from typing import Any, Optional, Type, TypeVar
 
 from .asset import _VALID_ANIMATED_ICON_FORMATS, _VALID_STATIC_ICON_FORMATS, Asset
 from .http import _PartialEmojiDict
+from .state import ConnectionState
 
 class _EmojiTag: ...
 
@@ -18,7 +19,7 @@ class PartialEmoji(_EmojiTag):
     @classmethod
     def with_state(
         cls: Type[_PE],
-        state: Any,
+        state: ConnectionState,
         *,
         name: Optional[str],
         animated: bool = ...,


### PR DESCRIPTION
Adding type hints for Emoji's `__init__` method. Also changed `state` in `PartialEmoji.with_state` from a generic `Any` to `ConnectionState`.